### PR TITLE
Update dnd5e manifest compatibility to 5.3.x

### DIFF
--- a/module.json
+++ b/module.json
@@ -22,8 +22,8 @@
                 "type": "system",
                 "compatibility": {
                     "minimum": "3.3.1",
-                    "verified": "5.2.5",
-                    "maximum": "5.2.x"
+                    "verified": "5.3.0",
+                    "maximum": "5.3.x"
                 }
             }
         ]


### PR DESCRIPTION
Updates module manifest compatibility for dnd5e 5.3.x by changing verified to 5.3.0 and maximum to 5.3.x.