### PR TITLE
chore: release v2.3.2 - dnd5e 5.3.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Bytes AI Foundry for Foundry VTT
 
 ![Foundry v13 Compatible](https://img.shields.io/badge/Foundry-v13-brightgreen?style=flat-square) ![Foundry v12 Compatible](https://img.shields.io/badge/Foundry-v12-green?style=flat-square) ![License](https://img.shields.io/badge/License-MIT-blue?style=flat-square)
-[![Version](https://img.shields.io/badge/Version-2.3.0-orange?style=flat-square)](https://github.com/f3rr311/Bytes-AI-Foundry/releases) [![D&D 5e](https://img.shields.io/badge/D%26D_5e-v3.3_%E2%80%93_v5.x-red?style=flat-square)](https://github.com/foundryvtt/dnd5e)
+[![Version](https://img.shields.io/badge/Version-2.3.2-orange?style=flat-square)](https://github.com/f3rr311/Bytes-AI-Foundry/releases) [![D&D 5e](https://img.shields.io/badge/D%26D_5e-v3.3_%E2%80%93_v5.x-red?style=flat-square)](https://github.com/foundryvtt/dnd5e)
 
 <br>
 
@@ -37,7 +37,7 @@
 >
 > ### Requirements
 >
-> - **System:** D&D 5e only (`dnd5e` v3.3.1 – v5.1.x)
+> - **System:** D&D 5e only (`dnd5e` v3.3.1 – v5.3.x)
 > - **Foundry VTT:** v12.331 – v13.351
 > - **API Key:** An API key for at least one [supported AI provider](#-multi-provider-ai-support) — [OpenAI](https://platform.openai.com/api-keys) (default), Anthropic, Google Gemini, xAI, or a local Ollama server.
 

--- a/Updates.md
+++ b/Updates.md
@@ -1,5 +1,24 @@
 # Update Logs
 
+## v2.3.2 — dnd5e 5.3.x Compatibility
+
+*Metadata-only release — no code changes.*
+
+* Verified compatibility with dnd5e system v5.3.0.
+* Updated dnd5e compatibility range: 3.3.1 – 5.3.x (verified 5.3.0).
+* Thanks to [@soteyl](https://github.com/soteyl) for the contribution ([#5](https://github.com/f3rr311/Bytes-AI-Foundry/pull/5)).
+
+---
+
+## v2.3.1 — dnd5e 5.2.x Compatibility
+
+*Metadata-only release — no code changes.*
+
+* Verified compatibility with dnd5e system v5.2.5.
+* Updated dnd5e compatibility range: 3.3.1 – 5.2.x (verified 5.2.5).
+
+---
+
 ## v2.3.0 — NPC & Character Generation, Multi-Provider AI, SRD Compliance
 
 *17 new files, 8 modified files, ~7,000 lines of new code.*

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "chatgpt-item-generator",
     "title": "Bytes AI Foundry",
     "description": "Generates AI-powered D&D 5e items, NPCs, characters, and roll tables with descriptions, effects, and images.",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "authors": [
         {
             "name": "Byte_Smarter",
@@ -29,7 +29,7 @@
         ]
     },
     "manifest": "https://github.com/f3rr311/Bytes-AI-Foundry/releases/latest/download/module.json",
-    "download": "https://github.com/f3rr311/Bytes-AI-Foundry/releases/download/v2.3.1/Bytes-AI-Foundry.zip",
+    "download": "https://github.com/f3rr311/Bytes-AI-Foundry/releases/download/v2.3.2/Bytes-AI-Foundry.zip",
     "readme": "https://github.com/f3rr311/Bytes-AI-Foundry/blob/main/README.md",
     "changelog": "https://github.com/f3rr311/Bytes-AI-Foundry/releases",
     "license": "https://github.com/f3rr311/Bytes-AI-Foundry/blob/main/LICENSE",


### PR DESCRIPTION
Bumps module version to 2.3.2 and updates the release zip download URL to the v2.3.2 tag. README requirements line and badge updated to reflect dnd5e 5.3.x support. Updates.md gains v2.3.1 (catch-up) and v2.3.2 entries.