### PR TITLE
feat: add Google Gemini image generation provider

### DIFF
--- a/scripts/api/openai.js
+++ b/scripts/api/openai.js
@@ -8,6 +8,7 @@ import { generateSDImage } from './stable-diffusion.js';
 import { stabilityAIProvider } from './providers/stability-ai-provider.js';
 import { falAIProvider } from './providers/fal-ai-provider.js';
 import { xaiImageProvider } from './providers/xai-image-provider.js';
+import { geminiImageProvider } from './providers/gemini-image-provider.js';
 import { MODULE_ID } from '../settings.js';
 import { routeChatCompletion } from './provider-registry.js';
 import {
@@ -457,6 +458,10 @@ export async function generateItemImage(prompt, config) {
     const imagePath = await xaiImageProvider.generateImage(finalPrompt, config);
     if (imagePath) trackImageGeneration();
     return imagePath;
+  } else if (imageProvider === "gemini-image") {
+    const imagePath = await geminiImageProvider.generateImage(finalPrompt, config);
+    if (imagePath) trackImageGeneration();
+    return imagePath;
   }
 
   // OpenAI image generation (default or fallback)
@@ -748,6 +753,8 @@ export async function generateActorImage(prompt, imageType, config) {
     return falAIProvider.generateImage(imagePrompt, { ...config, imageFolder: targetFolder });
   } else if (imageProvider === "xai") {
     return xaiImageProvider.generateImage(imagePrompt, { ...config, imageFolder: targetFolder });
+  } else if (imageProvider === "gemini-image") {
+    return geminiImageProvider.generateImage(imagePrompt, { ...config, imageFolder: targetFolder });
   }
 
   // OpenAI image generation (default)

--- a/scripts/api/providers/gemini-image-provider.js
+++ b/scripts/api/providers/gemini-image-provider.js
@@ -1,0 +1,102 @@
+/**
+ * Google Gemini image provider.
+ * Supports Gemini native image generation models (gemini-*-image) via generateContent,
+ * and Imagen 4 (imagen-4.0-*) via the predict endpoint.
+ * API key is shared with the Gemini text provider (geminiApiKey).
+ */
+
+import { ensureFolder, saveImageLocally } from '../../utils/file-utils.js';
+
+const DEFAULT_MODEL = "gemini-3.1-flash-image";
+const BASE_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta";
+
+// ─── Provider Definition ───
+
+export const geminiImageProvider = {
+  id: "gemini-image",
+  name: "Google Gemini (Imagen)",
+  requiresApiKey: true,
+
+  /**
+   * Generate an image using Google's Gemini image models or Imagen 4.
+   * @param {string} prompt — final image prompt
+   * @param {GeneratorConfig} config — module config with geminiApiKey, imageModel, imageFolder
+   * @returns {Promise<string|null>} path to saved image file, or null on failure
+   */
+  async generateImage(prompt, config) {
+    if (!config.geminiApiKey) {
+      console.error("Gemini Image: no API key configured.");
+      return null;
+    }
+
+    const model = config.imageModel || DEFAULT_MODEL;
+    // Imagen 4 models use the predict endpoint; all others use generateContent
+    const isImagen = model.startsWith("imagen-");
+
+    let url, body;
+
+    if (isImagen) {
+      url = `${BASE_ENDPOINT}/models/${model}:predict?key=${config.geminiApiKey}`;
+      body = {
+        instances: [{ prompt }],
+        parameters: { sampleCount: 1 }
+      };
+    } else {
+      url = `${BASE_ENDPOINT}/models/${model}:generateContent?key=${config.geminiApiKey}`;
+      body = {
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+        generationConfig: { responseModalities: ["IMAGE", "TEXT"] }
+      };
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => "");
+        console.error(`Gemini image API error ${response.status}: ${errorBody}`);
+        return null;
+      }
+
+      const data = await response.json();
+
+      let b64, mimeType;
+
+      if (isImagen) {
+        const prediction = data.predictions?.[0];
+        if (!prediction?.bytesBase64Encoded) {
+          console.error("Gemini Imagen: no image data in response.", data);
+          return null;
+        }
+        b64 = prediction.bytesBase64Encoded;
+        mimeType = prediction.mimeType || "image/png";
+      } else {
+        // Find the inline image part in the generateContent response
+        const parts = data.candidates?.[0]?.content?.parts || [];
+        const imagePart = parts.find(p => p.inlineData?.mimeType?.startsWith("image/"));
+        if (!imagePart) {
+          console.error("Gemini Image: no image part in response.", data);
+          return null;
+        }
+        b64 = imagePart.inlineData.data;
+        mimeType = imagePart.inlineData.mimeType;
+      }
+
+      const ext = mimeType === "image/jpeg" ? "jpg" : "png";
+      const dataUrl = `data:${mimeType};base64,${b64}`;
+      const shortName = prompt.replace(/[^a-zA-Z0-9 ]/g, "").split(/\s+/).slice(0, 4).join("_").toLowerCase();
+      const fileName = `${shortName}_${Date.now()}.${ext}`;
+      const targetFolder = config.imageFolder;
+      await ensureFolder(targetFolder);
+
+      return await saveImageLocally(dataUrl, fileName, targetFolder);
+    } catch (err) {
+      console.error("Gemini image request failed:", err.message);
+      return null;
+    }
+  }
+};

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -28,7 +28,7 @@ import { NAME_KEYWORDS } from './utils/type-keywords.js';
  * @property {string|null} dnd5eVersion — dnd5e system version string, or null
  * @property {boolean} isV13Core — true if Foundry core version >= 13
  * @property {string} textProvider — "openai"|"anthropic"|"gemini"|"xai"|"ollama"|"custom"
- * @property {string} imageProvider — "openai"|"stable-diffusion"|"stability-ai"|"fal-ai"
+ * @property {string} imageProvider — "openai"|"stable-diffusion"|"stability-ai"|"fal-ai"|"gemini-image"
  * @property {string} anthropicApiKey — Anthropic API key
  * @property {string} geminiApiKey — Google Gemini API key
  * @property {string} xaiApiKey — xAI API key

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -20,7 +20,8 @@ export const IMAGE_MODEL_DEFAULTS = {
   "xai":              "grok-imagine-image",
   "stable-diffusion": "",
   "stability-ai":     "stable-diffusion-xl-1024-v0-9",
-  "fal-ai":           "fal-ai/flux/dev"
+  "fal-ai":           "fal-ai/flux/dev",
+  "gemini-image":     "gemini-3.1-flash-image"
 };
 
 /**
@@ -238,7 +239,8 @@ export function registerSettings() {
       "xai":               "xAI Grok (Grok Imagine)",
       "stable-diffusion":  "Stable Diffusion (Local)",
       "stability-ai":      "Stability AI",
-      "fal-ai":            "FAL.ai (FLUX, Recraft, Ideogram)"
+      "fal-ai":            "FAL.ai (FLUX, Recraft, Ideogram)",
+      "gemini-image":      "Google Gemini (Imagen)"
     },
     group: MODULE_ID + ".image-provider",
     onChange: async (value) => {
@@ -280,7 +282,7 @@ export function registerSettings() {
   // ─── Image Model & Format ───
   game.settings.register(MODULE_ID, "imageModel", {
     name: "Image Generation Model",
-    hint: "* Auto-set when you switch Image AI Provider. You can override with any model your provider supports. Examples — OpenAI: gpt-image-1, dall-e-3. Stability AI: stable-image-core. FAL.ai: fal-ai/flux/dev, fal-ai/recraft-v3.",
+    hint: "* Auto-set when you switch Image AI Provider. You can override with any model your provider supports. Examples — OpenAI: gpt-image-1, dall-e-3. Stability AI: stable-image-core. FAL.ai: fal-ai/flux/dev, fal-ai/recraft-v3. Gemini (generateContent): gemini-3.1-flash-image (default), gemini-2.5-flash-image, gemini-3-pro-image. Gemini (Imagen 4, predict): imagen-4.0-generate-001, imagen-4.0-fast-generate-001.",
     scope: "world",
     config: true,
     type: String,
@@ -414,7 +416,7 @@ export function registerSettings() {
   });
   game.settings.register(MODULE_ID, "dallePrompt", {
     name: "Image Prompt",
-    hint: "Template sent to the image model. {prompt} is replaced with the item's name + description. Everything else is the art style. Applies to every image provider (OpenAI, xAI, Stability, FAL).",
+    hint: "Template sent to the image model. {prompt} is replaced with the item's name + description. Everything else is the art style. Applies to every image provider (OpenAI, xAI, Stability, FAL, Gemini).",
     scope: "world",
     config: true,
     type: String,


### PR DESCRIPTION
Adds a new image provider "Google Gemini (Imagen)" that routes through the same key already used for Gemini text generation (geminiApiKey).

- New file: scripts/api/providers/gemini-image-provider.js Supports Gemini native image models (gemini-*-image) via generateContent and Imagen 4 (imagen-4.0-*) via the predict endpoint. Model is auto-detected by prefix so users can switch between them via the Image Model field without any code changes.

- settings.js: added "gemini-image" to IMAGE_MODEL_DEFAULTS (default: gemini-3.1-flash-image), added to imageProvider choices dropdown, updated imageModel and dallePrompt hints with Gemini model examples.

- openai.js: imported geminiImageProvider and wired it into both generateItemImage and generateActorImage routing blocks.

- main.js: updated GeneratorConfig typedef to include "gemini-image".

No new API key setting is needed — geminiApiKey is shared between text and image generation.